### PR TITLE
Codegen

### DIFF
--- a/neural/codegen/symbolic.py
+++ b/neural/codegen/symbolic.py
@@ -407,14 +407,14 @@ class SympyGenerator(with_metaclass(MetaClass, VariableAnalyzer)):
     def handle_compare_op(self, ins):
         """Convert Comparison Operation to Heaviside Expressions"""
         op = ins.argval
-        if op in ['>', '>=']:
-            diff =f"{self.var[-2]} - {self.var[-1]}"
-        elif op in ['<', '<=']:
-            diff =f"{self.var[-1]} - {self.var[-2]}"
+        if op in [">", ">="]:
+            diff = f"{self.var[-2]} - {self.var[-1]}"
+        elif op in ["<", "<="]:
+            diff = f"{self.var[-1]} - {self.var[-2]}"
         else:
             raise ValueError(f"Comparison with Operator '{op}' not understood.")
 
-        thres = 1 if '=' in op else 0
+        thres = 1 if "=" in op else 0
 
         self.var[-2] = f"Heaviside({diff}, {thres})"
         del self.var[-1]

--- a/neural/codegen/symbolic.py
+++ b/neural/codegen/symbolic.py
@@ -408,9 +408,9 @@ class SympyGenerator(with_metaclass(MetaClass, VariableAnalyzer)):
         """Convert Comparison Operation to Heaviside Expressions"""
         op = ins.argval
         if op in [">", ">="]:
-            diff = f"{self.var[-2]} - {self.var[-1]}"
+            diff = f"({self.var[-2]}) - ({self.var[-1]})"
         elif op in ["<", "<="]:
-            diff = f"{self.var[-1]} - {self.var[-2]}"
+            diff = f"({self.var[-1]}) - ({self.var[-2]})"
         else:
             raise ValueError(f"Comparison with Operator '{op}' not understood.")
 

--- a/neural/codegen/symbolic.py
+++ b/neural/codegen/symbolic.py
@@ -304,7 +304,8 @@ class SympyGenerator(with_metaclass(MetaClass, VariableAnalyzer)):
                 tmp = latex(self.sympy_dct[eq], mul_symbol="dot")
             except Exception as e:
                 raise err.NeuralSymPyCodeGenError(
-                    f"Failed to Generate Sympy Code for model {self.model.__class__.__name__}"
+                    "Failed to Generate Sympy Code for model"
+                    f" {self.model.__class__.__name__}"
                 ) from e
             self.latex_src += tmp.replace("=", " &=& ") + r"\\"
         self.latex_src += r"\end{eqnarray}"

--- a/neural/codegen/symbolic.py
+++ b/neural/codegen/symbolic.py
@@ -283,9 +283,9 @@ class SympyGenerator(with_metaclass(MetaClass, VariableAnalyzer)):
                         "SymPy Compilation Failed for model"
                         f" '{self.model.__class__.__name__}' on:"
                         f" Line {n}: \n{line}"
-                         "\n This is likely an issue with using 'elif' statement"
-                         " , avoid 'elif' and prefer binary masking operators"
-                         " like '(x>0)*x' in general."
+                        "\n This is likely an issue with using 'elif' statement"
+                        " , avoid 'elif' and prefer binary masking operators"
+                        " like '(x>0)*x' in general."
                     ) from e
                 except Exception as e:
                     raise err.NeuralSymPyCodeGenError(

--- a/neural/codegen/symbolic.py
+++ b/neural/codegen/symbolic.py
@@ -247,7 +247,7 @@ class SympyGenerator(with_metaclass(MetaClass, VariableAnalyzer)):
         for key in dir(self):
             if key[:8] == "_handle_":
                 setattr(self, key[1:], getattr(self, key))
-        #
+
         self.generate()
         self.get_symbols()
         self.sympy_dct = {}
@@ -281,8 +281,9 @@ class SympyGenerator(with_metaclass(MetaClass, VariableAnalyzer)):
                 except Exception as e:
                     # print(self.sympy_src)
                     raise err.NeuralSymPyCodeGenError(
-                        f"""SymPy Compilation Failed for model {self.model.__class__.__name__} on:
-                        Line {n}: {line}"""
+                        "SymPy Compilation Failed for model"
+                        f" '{self.model.__class__.__name__}' on:"
+                        f" Line {n}: \n{line}"
                     ) from e
 
     def to_latex(self):
@@ -402,6 +403,21 @@ class SympyGenerator(with_metaclass(MetaClass, VariableAnalyzer)):
         else:
             self.var.append("")
             self.output_statement()
+
+    def handle_compare_op(self, ins):
+        """Convert Comparison Operation to Heaviside Expressions"""
+        op = ins.argval
+        if op in ['>', '>=']:
+            diff =f"{self.var[-2]} - {self.var[-1]}"
+        elif op in ['<', '<=']:
+            diff =f"{self.var[-1]} - {self.var[-2]}"
+        else:
+            raise ValueError(f"Comparison with Operator '{op}' not understood.")
+
+        thres = 1 if '=' in op else 0
+
+        self.var[-2] = f"Heaviside({diff}, {thres})"
+        del self.var[-1]
 
     def _handle_return_value(self, ins):
         self.var[-1] = ""

--- a/neural/codegen/symbolic.py
+++ b/neural/codegen/symbolic.py
@@ -278,8 +278,16 @@ class SympyGenerator(with_metaclass(MetaClass, VariableAnalyzer)):
             for n, line in enumerate(self.sympy_src.split("\n")):
                 try:
                     exec(line, globals(), self.sympy_dct)
+                except IndentationError as e:
+                    raise err.NeuralSymPyCodeGenError(
+                        "SymPy Compilation Failed for model"
+                        f" '{self.model.__class__.__name__}' on:"
+                        f" Line {n}: \n{line}"
+                         "\n This is likely an issue with using 'elif' statement"
+                         " , avoid 'elif' and prefer binary masking operators"
+                         " like '(x>0)*x' in general."
+                    ) from e
                 except Exception as e:
-                    # print(self.sympy_src)
                     raise err.NeuralSymPyCodeGenError(
                         "SymPy Compilation Failed for model"
                         f" '{self.model.__class__.__name__}' on:"

--- a/neural/network/operator.py
+++ b/neural/network/operator.py
@@ -93,9 +93,6 @@ class Add(Operator):
                 "aggregate",
             )
         else:
-            import pdb
-
-            pdb.set_trace()
             raise NotImplementedError
 
 

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import random
 
 # pylint:disable=import-error
@@ -21,6 +22,7 @@ class FakeModel(Model):
         else:
             self.z = 100
 
+        self.y = np.exp(np.cbrt(np.sqrt(self.z))) + random.gauss(0.0, self.c)
         self.y = (self.y > self.z) * self.y
         self.y = (self.y < self.z) * self.y
         self.y = (self.y >= self.z) * self.y

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,0 +1,46 @@
+import pytest
+import random
+
+# pylint:disable=import-error
+from neural import Model
+from neural.codegen.symbolic import SympyGenerator
+
+# pylint:enable=import-error
+
+
+class FakeModel(Model):
+    Default_States = dict(x=0.0, y=0.0, z=0.0)
+    Default_Params = dict(a=1.0, b=2.0, c=10.0)
+
+    def ode(self, inp1=0.0, inp2=1.0):
+        self.d_x = self.a * (1 - self.x) + self.b * self.x
+        self.y = self.x * self.c
+        self.z = self.x * self.c
+        if self.z < 1:
+            self.z = 0
+        else:
+            self.z = 100
+
+        self.y = (self.y > self.z) * self.y
+        self.y = (self.y < self.z) * self.y
+        self.y = (self.y >= self.z) * self.y
+        self.y = (self.y <= self.z) * self.y
+
+        self.y = (self.y > 2) * self.y
+        self.y = (self.y < 2) * self.y
+        self.y = (self.y >= 2) * self.y
+        self.y = (self.y <= 2) * self.y
+
+        self.y = (self.y > self.c) * self.y
+        self.y = (self.y < self.c) * self.y
+        self.y = (self.y >= self.c) * self.y
+        self.y = (self.y <= self.c) * self.y
+
+
+@pytest.fixture
+def model():
+    return FakeModel()
+
+
+def test_sympy_gen(model):
+    sg = SympyGenerator(model)


### PR DESCRIPTION
This is a suboptimal fix for #12 for expressions of the form `(x>0)*x`

Ideally we should be able to capture conditional statement in (if/else) and parse the assignment statement in the conditional statement to convert the result into `Piecewise` statement that will render the output nicely into `\begin{case}` statements in latex. However, doing this in general (especially with `dis.dis`) is difficult without enforcing specific semantic constraints (perhaps with our own implementation of `piecewise` that is compatible with NumPy execution). 

In the spirit of imposing _minimal_ semantic requirements on ODE specification, I opted for using `Heaviside` to convert comparison operation to a Sympy expression.